### PR TITLE
Support when final line is removed but no new line is added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+*.patch text eol=lf

--- a/__tests__/data/complex.json
+++ b/__tests__/data/complex.json
@@ -334,6 +334,13 @@
                 "newIndex": 186,
                 "oldValue": "  }",
                 "newValue": "  }"
+            },
+            {
+                "type": "removed",
+                "oldIndex": 186,
+                "newIndex": null,
+                "oldValue": "",
+                "newValue": null
             }
         ]
     }

--- a/__tests__/data/complex.patch
+++ b/__tests__/data/complex.patch
@@ -49,3 +49,4 @@
        stageVariables: null,
      }
    }
+-

--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,10 @@ function parse(patchHunks) {
             const newLine = new Line(hunk.header.oldStart + hunk.lines.length - offset.add, hunk.header.newStart + hunk.lines.length - offset.del, line);
 
             if (line.startsWith("-")) {
-                if (lines[i+1].startsWith("+")) {
+                const nextLine = lines[i+1];
+                if (nextLine && nextLine.startsWith("+")) {
                     newLine.type = "changed";
-                    newLine.setNewValue(lines[i+1]);
+                    newLine.setNewValue(nextLine);
                     i++;
                 } else {
                     newLine.type = "removed";


### PR DESCRIPTION
I'm using this with patches from GitHub's API and a few of them had the final line of the patch as a removed line but no new line after it. That was causing the following error to be thrown:

```text
...\node_modules\parse-patch-hunks\src\index.js:69
                if (lines[i+1].startsWith("+")) {
                               ^

TypeError: Cannot read properties of undefined (reading 'startsWith')
    at parse (C:\dev\node_modules\parse-patch-hunks\src\index.js:69:32)
    at file:///C:/dev/todo.js:52:15

Node.js v20.6.0
```

There's two ways to fix this but I wasn't sure what language features you wanted to use. This also works `lines{i+1}?.startsWith()`.

I'm on Windows so the tests were failing until I switched the `.patch` files from `CrLf` to `Lf`, that's why I added the `.gitattributes` file.
